### PR TITLE
Replace six from django.utils with the external package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,11 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.5',
     ],
+    install_requires=['six'],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-softdelete-it',
-    version='0.1',
+    version='0.2',
     packages=find_packages(),
     include_package_data=True,
     license='MIT License',

--- a/soft_delete_it/models.py
+++ b/soft_delete_it/models.py
@@ -6,8 +6,8 @@ from django.db import (models, router, transaction)
 from django.db.models import signals, sql
 from django.contrib.admin.utils import NestedObjects
 from django.db.models.fields import FieldDoesNotExist
-from django.utils import six
 from operator import attrgetter
+import six
 
 
 class SoftDeleteHelper():

--- a/soft_delete_it/models.py
+++ b/soft_delete_it/models.py
@@ -5,7 +5,7 @@ from collections import Counter
 from django.db import (models, router, transaction)
 from django.db.models import signals, sql
 from django.contrib.admin.utils import NestedObjects
-from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
 from operator import attrgetter
 import six
 


### PR DESCRIPTION
Django has removed six from django.utils package in order to drop support for Python 2:
https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis

All Django projects that use django-softdelete-it cannot be upgraded to 3.0 since six library is missing. A quick way to fix the issue is to replace six with the external package.